### PR TITLE
Fix permission error in mnist.py

### DIFF
--- a/dataset/mnist.py
+++ b/dataset/mnist.py
@@ -18,7 +18,7 @@ key_file = {
     'test_label':'t10k-labels-idx1-ubyte.gz'
 }
 
-dataset_dir = os.path.dirname(__file__)
+dataset_dir = os.path.dirname(os.path.abspath(__file__))
 save_file = dataset_dir + "/mnist.pkl"
 
 train_num = 60000


### PR DESCRIPTION
When I ran `dataset/mnist.py` to just download mnist data set, I got an error which said permission error.

```
~/Downloads/deep-learning-from-scratch-master/dataset
✔ python3 mnist.py
Downloading train-images-idx3-ubyte.gz ...
Traceback (most recent call last):
  File "mnist.py", line 128, in <module>
    init_mnist()
  File "mnist.py", line 75, in init_mnist
    download_mnist()
  File "mnist.py", line 42, in download_mnist
    _download(v)
  File "mnist.py", line 37, in _download
    urllib.request.urlretrieve(url_base + file_name, file_path)
  File "/usr/local/Cellar/python3/3.4.0/Frameworks/Python.framework/Versions/3.4/lib/python3.4/urllib/request.py", line 188, in urlretrieve
    tfp = open(filename, 'wb')
PermissionError: [Errno 13] Permission denied: '/train-images-idx3-ubyte.gz'
```

When `dataset/mnist.py` is used from other file like sample code in the book, this error never happened.
But when I ran this file,  `os.path.dirname(__file__)` returns empty and it makes `dataset_dir` empty. This causes a permission error for most of uses because `save_file` will be created at root path.
To avoid this, we have to convert current file path as absolute path then take its parent directory path.

This file seems to be written to be ran by itself (from `if __name__ == '__main__':` code), I'm thinking this change can help others who want to just download mnist data set.