### PR TITLE
fix dimentional error of gradient_2d

### DIFF
--- a/ch04/gradient_2d.py
+++ b/ch04/gradient_2d.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     X = X.flatten()
     Y = Y.flatten()
     
-    grad = numerical_gradient(function_2, np.array([X, Y]) )
+    grad = numerical_gradient(function_2, np.array([X, Y]).T).T
     
     plt.figure()
     plt.quiver(X, Y, -grad[0], -grad[1],  angles="xy",color="#666666")#,headwidth=10,scale=40,color="#444444")


### PR DESCRIPTION
_numerical_gradient_no_batch(f, x)内で，f(x)に渡されるxが，(x0, x1)ではなく，324次元のx_0になっています．出力される勾配とグラフは同じですが，計算の意味合いとしては，(x0, x1)の方が正しいのではないでしょうか．(間違ってたらすみません)