### PR TITLE
train and test results are swapped

### DIFF
--- a/ch06/overfit_dropout.py
+++ b/ch06/overfit_dropout.py
@@ -23,7 +23,7 @@ trainer = Trainer(network, x_train, t_train, x_test, t_test,
                   optimizer='sgd', optimizer_param={'lr': 0.01}, verbose=True)
 trainer.train()
 
-train_acc_list, test_acc_list = trainer.test_acc_list, trainer.train_acc_list
+train_acc_list, test_acc_list = trainer.train_acc_list, trainer.test_acc_list
 
 # グラフの描画==========
 markers = {'train': 'o', 'test': 's'}


### PR DESCRIPTION
train_acc_list and test_acc_list of `trainer` are assigned to wrong variables so train and test results are swapped in `overfit_dropout.py`.
As a result, plots in Fig 6-23 are labeled wrongly.
