### PR TITLE
fix NameError

### DIFF
--- a/ch07/train_convnet.py
+++ b/ch07/train_convnet.py
@@ -14,12 +14,14 @@ from common.trainer import Trainer
 #x_train, t_train = x_train[:5000], t_train[:5000]
 #x_test, t_test = x_test[:1000], t_test[:1000]
 
+max_epochs = 20
+
 network = SimpleConvNet(input_dim=(1,28,28), 
                         conv_param = {'filter_num': 30, 'filter_size': 5, 'pad': 0, 'stride': 1},
                         hidden_size=100, output_size=10, weight_init_std=0.01)
                         
 trainer = Trainer(network, x_train, t_train, x_test, t_test,
-                  epochs=20, mini_batch_size=100,
+                  epochs=max_epochs, mini_batch_size=100,
                   optimizer='Adam', optimizer_param={'lr': 0.001},
                   evaluate_sample_num_per_epoch=1000)
 trainer.train()


### PR DESCRIPTION
Running ch07/train_convnet.py causes following error.

```
Traceback (most recent call last):
  File "train_convnet.py", line 33, in <module>
    x = np.arange(max_epochs)
NameError: name 'max_epochs' is not defined
```