### PR TITLE
Use os.pardir when modifying sys.path

### DIFF
--- a/ch05/train_neuralnet.py
+++ b/ch05/train_neuralnet.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 import sys, os
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(os.pardir)
 
 import numpy as np
 from dataset.mnist import load_mnist


### PR DESCRIPTION

In the book and the other source codes except `ch05/train_neuralnet.py` uses
```
sys.path.append(os.pardir)
```
but `ch05/train_neuralnet.py` uses
```
sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
```
to add the parent directory to `sys.path`.

With this fix, you can run `exec(open('train_neuralnet.py').read())` successfully on Python3 prompt in `ch05` directory.