### PR TITLE
Add mnist.pkl to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.gz
 *.pyc
 __pycache__/
+mnist.pkl


### PR DESCRIPTION
`mnist.pkl` should be included in `.gitignore` so that the working tree remains clean after `download_mnist()`.