### PR TITLE
TypeError: slice indices must be integers

### DIFF
--- a/ch06/hyperparameter_optimization.py
+++ b/ch06/hyperparameter_optimization.py
@@ -16,7 +16,7 @@ t_train = t_train[:500]
 
 # 検証データの分離
 validation_rate = 0.20
-validation_num = x_train.shape[0] * validation_rate
+validation_num = int(x_train.shape[0] * validation_rate)
 x_train, t_train = shuffle_dataset(x_train, t_train)
 x_val = x_train[:validation_num]
 t_val = t_train[:validation_num]


### PR DESCRIPTION
     19 validation_num = x_train.shape[0] * validation_rate
     20 x_train, t_train = shuffle_dataset(x_train, t_train)
---> 21 x_val = x_train[:validation_num]
     22 t_val = t_train[:validation_num]
     23 x_train = x_train[validation_num:]

TypeError: slice indices must be integers or None or have an __index__ method