### PR TITLE
Fix typo of sum_squared_error at common.functions

### DIFF
--- a/common/functions.py
+++ b/common/functions.py
@@ -40,7 +40,7 @@ def softmax(x):
 
 
 def sum_squared_error(y, t):
-    return 0.5 * np.sum((y-t)**2)
+    return np.sum((y-t)**2)/len(y)
 
 
 def cross_entropy_error(y, t):


### PR DESCRIPTION
wrong expression for sum_squared_error(mean_squared_error) function