### PR TITLE
int -> int32

### DIFF
--- a/ch03/sig_step_compare.py
+++ b/ch03/sig_step_compare.py
@@ -8,7 +8,7 @@ def sigmoid(x):
 
 
 def step_function(x):
-    return np.array(x > 0, dtype=np.int)
+    return np.array(x > 0, dtype=np.int32)
 
 x = np.arange(-5.0, 5.0, 0.1)
 y1 = sigmoid(x)

--- a/ch03/step_function.py
+++ b/ch03/step_function.py
@@ -4,7 +4,7 @@ import matplotlib.pylab as plt
 
 
 def step_function(x):
-    return np.array(x > 0, dtype=np.int)
+    return np.array(x > 0, dtype=np.int32)
 
 X = np.arange(-5.0, 5.0, 0.1)
 Y = step_function(X)


### PR DESCRIPTION
実行時に以下のようなエラーが出たので修正しました

```
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
```

https://numpy.org/devdocs/release/1.20.0-notes.html