### PR TITLE
[ch04]各epochごとにすべての訓練データを見るようにする

### DIFF
--- a/ch04/train_neuralnet.py
+++ b/ch04/train_neuralnet.py
@@ -11,7 +11,7 @@ from two_layer_net import TwoLayerNet
 
 network = TwoLayerNet(input_size=784, hidden_size=50, output_size=10)
 
-iters_num = 10000  # 繰り返しの回数を適宜設定する
+epoch_num = 20
 train_size = x_train.shape[0]
 batch_size = 100
 learning_rate = 0.1
@@ -20,30 +20,33 @@ train_loss_list = []
 train_acc_list = []
 test_acc_list = []
 
-iter_per_epoch = max(train_size / batch_size, 1)
+iter_per_epoch = max(train_size // batch_size, 1)
 
-for i in range(iters_num):
-    batch_mask = np.random.choice(train_size, batch_size)
-    x_batch = x_train[batch_mask]
-    t_batch = t_train[batch_mask]
-    
-    # 勾配の計算
-    #grad = network.numerical_gradient(x_batch, t_batch)
-    grad = network.gradient(x_batch, t_batch)
-    
-    # パラメータの更新
-    for key in ('W1', 'b1', 'W2', 'b2'):
-        network.params[key] -= learning_rate * grad[key]
-    
-    loss = network.loss(x_batch, t_batch)
-    train_loss_list.append(loss)
-    
-    if i % iter_per_epoch == 0:
-        train_acc = network.accuracy(x_train, t_train)
-        test_acc = network.accuracy(x_test, t_test)
-        train_acc_list.append(train_acc)
-        test_acc_list.append(test_acc)
-        print("train acc, test acc | " + str(train_acc) + ", " + str(test_acc))
+
+for epoch in range(epoch_num):
+    perm = np.random.permutation(train_size)
+
+    for i in range(iter_per_epoch):
+        batch_mask = perm[i * batch_size : (i + 1) * batch_size]
+        x_batch = x_train[batch_mask]
+        t_batch = t_train[batch_mask]
+
+        # 勾配の計算
+        #grad = network.numerical_gradient(x_batch, t_batch)
+        grad = network.gradient(x_batch, t_batch)
+
+        # パラメータの更新
+        for key in ('W1', 'b1', 'W2', 'b2'):
+            network.params[key] -= learning_rate * grad[key]
+
+        loss = network.loss(x_batch, t_batch)
+        train_loss_list.append(loss)
+
+    train_acc = network.accuracy(x_train, t_train)
+    test_acc = network.accuracy(x_test, t_test)
+    train_acc_list.append(train_acc)
+    test_acc_list.append(test_acc)
+    print("train acc, test acc | " + str(train_acc) + ", " + str(test_acc))
 
 # グラフの描画
 markers = {'train': 'o', 'test': 's'}


### PR DESCRIPTION
## 概要
**4.5 学習アルゴリズムの実装** における
ニューラルネットワークのミニバッチ学習ループを `iters_num` から `epoch`, `iter_per_epoch` に変更し、
毎epochで全訓練データを一度ずつ使用するようにしました。

## 変更点
- `np.random.choice` → `np.random.permutation` と `slice` を用いた非復元抽出に変更
- `iters_num` ベース → `epoch` ベースのループに書き換え
- `iter_per_epoch = max(train_size / batch_size, 1)` の結果が小数点以下を含むと正しくコードが動かないので修正


## 背景
従来の choice によるサンプリングでは、同一データの重複使用や未使用のままのデータが発生し、  
全体の損失最小化や収束性に悪影響を及ぼす可能性がありました。

## 動作確認
ローカルでの動作確認を行いました。

```
 ❯ python train_neuralnet.py
train acc, test acc | 0.7893833333333333, 0.7959
train acc, test acc | 0.8759833333333333, 0.8793
train acc, test acc | 0.89965, 0.9029
train acc, test acc | 0.9085166666666666, 0.9105
train acc, test acc | 0.9157333333333333, 0.9169
train acc, test acc | 0.9207666666666666, 0.9214
train acc, test acc | 0.9244666666666667, 0.9257
train acc, test acc | 0.9285333333333333, 0.9276
train acc, test acc | 0.9321666666666667, 0.9311
train acc, test acc | 0.9351833333333334, 0.9341
train acc, test acc | 0.9375666666666667, 0.9367
train acc, test acc | 0.9402666666666667, 0.9395
train acc, test acc | 0.9425166666666667, 0.9409
train acc, test acc | 0.9444, 0.9423
train acc, test acc | 0.9466666666666667, 0.9454
train acc, test acc | 0.9480833333333333, 0.9455
train acc, test acc | 0.9496666666666667, 0.9473
train acc, test acc | 0.95175, 0.9479
train acc, test acc | 0.9527333333333333, 0.9489
train acc, test acc | 0.9542166666666667, 0.9498
```